### PR TITLE
LUT-26750: [Components] remove the Jenkins column

### DIFF
--- a/webapp/WEB-INF/templates/skin/plugins/lutecetools/components.html
+++ b/webapp/WEB-INF/templates/skin/plugins/lutecetools/components.html
@@ -151,7 +151,7 @@
                         <th>&nbsp;</th>
                         <th colspan="3" id="7">Jira</th>
                         <th id="8">Release</th>
-                        <th id="9">Jenkins</th>
+<!--                        <th id="9">Jenkins</th>-->
                         <th id="10">#i18n{lutecetools.components.labelLinks}</th>
                     </tr>
                     <tr>
@@ -350,10 +350,10 @@
                                 <span class="hidden">0</span>
                             </#if>
                         </td>
-                        <td class="small">
-                            <span class="hidden">${component.attributes.jenkinsStatus!''}</span> 
+<!--                    <td class="small">
+                            <span class="hidden">${component.attributes.jenkinsStatus!''}</span>
                             <a href="${component.attributes.jenkinsJobBuildUrl!''}"><img src="${component.attributes.jenkinsJobBadgeIconUrl!''}"></a>
-                        </td>
+                        </td> -->
                         <td>
                             <a href="https://dev.lutece.paris.fr/jira/projects/${component.attributes.jiraKey!''}" title="JIRA">
                                 <img src="images/skin/plugins/lutecetools/jira.png" alt="Jira logo" width="24" height="24"/>


### PR DESCRIPTION
https://dev.lutece.paris.fr/bugtracker/issues/26750 
 in preparation for adding a new Jenkins column, I have temporarily commented out the existing "not updatable" column.

The rationale behind this approach is to facilitate the forthcoming addition of the new Jenkins column [[Components] create a new Jenkins column](https://dev.lutece.paris.fr/bugtracker/issues/26751)  without disrupting the current functionality. Once the new column is added, the necessary adjustments will be made accordingly.